### PR TITLE
feat: integrate cobra with the --merge flag/command

### DIFF
--- a/docs/dev_docs/read_and_write.md
+++ b/docs/dev_docs/read_and_write.md
@@ -18,3 +18,7 @@ GoLang's own site on this package: https://pkg.go.dev/html/template
 
 Currently it can convert data from a CLI command to html.
 
+go run "<Url> <branch> <filepath>"
+
+example 
+go run "https://github.com/NovoNordisk-OpenSource/decentralized-tech-radar main whitelist.txt"

--- a/src/cmd/merge.go
+++ b/src/cmd/merge.go
@@ -6,27 +6,32 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/NovoNordisk-OpenSource/decentralized-tech-radar/Merger"
 	"github.com/spf13/cobra"
 )
 
 // mergeCmd represents the merge command
 var mergeCmd = &cobra.Command{
-	Use:   "merge",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Use:   "merge \"<FilePath1> <FilePath2> [FilePath3, ...]\"",
+	Short: "This command merges one or more CSV-files into one.",
+	Long: `This command reads data from each provided CSV-file and writes the data into a singular file in the order given as arguments.
+	
+<> are mandatory inputs, whereas [] are optional inputs.
+Example of a <FilePath>: 'C://Program/MyCSVFile.csv'.
+Example of command usage: 'merge C://Program/MyCSVFile.csv C://Program/MyCSVFile1.csv'`,
+	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 2 {
+			panic("Not enough arguments have been provided.")
+		}
+		Merger.MergeCSV(args)
 		fmt.Println("merge called")
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(mergeCmd)
-
+	//Have kept this for future reference to make the --cache command.
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/src/cmd/merge.go
+++ b/src/cmd/merge.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// mergeCmd represents the merge command
+var mergeCmd = &cobra.Command{
+	Use:   "merge",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("merge called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(mergeCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// mergeCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// mergeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "tech_radar",
+	Short: "A tool for generating tech radar from csv specfiles",
+	Long: `Work in progress`,
+}
+
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+
+}
+
+

--- a/src/go.mod
+++ b/src/go.mod
@@ -3,3 +3,9 @@ module github.com/NovoNordisk-OpenSource/decentralized-tech-radar
 go 1.21.1
 
 require github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.8.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,2 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a h1:RYfmiM0zluBJOiPDJseKLEN4BapJ42uSi9SZBQ2YyiA=
 github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/main.go
+++ b/src/main.go
@@ -1,58 +1,9 @@
 package main
 
-import (
-	"flag"
-	"fmt"
-	"os"
-	"strings"
-	"github.com/NovoNordisk-OpenSource/decentralized-tech-radar/Fetcher"
-	"github.com/NovoNordisk-OpenSource/decentralized-tech-radar/Merger"
-	"github.com/NovoNordisk-OpenSource/decentralized-tech-radar/SpecReader"
-	html "github.com/NovoNordisk-OpenSource/decentralized-tech-radar/HTML"
-)
+import "github.com/NovoNordisk-OpenSource/decentralized-tech-radar/cmd"
+
+
 
 func main() {
-	var repos []Fetcher.Repo
-  
-	file := flag.String("file", "", "This takes a path to a csv file/string")
-	fetch := flag.String("fetch", "", "This command will fetch a file from a git repo")
-	merge := flag.String("merge", "", "This takes paths to files that should be merged (space separated)")
-	flag.Parse()
-
-	if *fetch != "" {
-		fetchArgs := strings.Split(*fetch, " ")
-		if len(fetchArgs) < 3 || len(fetchArgs) % 3 != 0{
-			fmt.Println(string(fetchArgs[0]) + " " + " Incorrect number of arguments for fetch command")
-			os.Exit(1)
-		}
-
-		// Iterate through command-line arguments after flags
-		// Go by every group of 3 arguments
-		for i := 0; i < len(fetchArgs)-2; i += 3 {
-			// Check for flag and enough arguments
-			repo := Fetcher.Repo{fetchArgs[i], fetchArgs[i+1], fetchArgs[i+2]} // Extract repository details
-			repos = append(repos, repo)
-		}
-
-		// Call the Fetcher package function to fetch files from all repositories
-		err := Fetcher.ListingReposForFetch(repos)
-		if err != nil {
-			fmt.Println("Error fetching files:", err)
-			os.Exit(1)
-		}
-		os.Exit(0)
-    } 
-	
-
-	if *merge != "" {
-		err := Merger.MergeCSV(strings.Split(*merge, " "))
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	if *file != "" && *fetch == "" {
-		specs := SpecReader.ReadCsvSpec(*file)
-		html.GenerateHtml(specs)
-	}
+	cmd.Execute()
 }


### PR DESCRIPTION
This PR includes integration of the merge command for merging two or more CSV-data into one CSV-file.

To use this:
`go run main.go merge "<FilePath1> <FilePath2> [FilePath3, ...]"`

Mandatory vs. optional arguments
`<>` indicates mandatory arguments, while ´[]` indicates optional arguments.

Resolves [#56](https://github.com/NovoNordisk-OpenSource/decentralized-tech-radar/issues/56)