### PR TITLE
refactor: split verifier function into two calls and ...

### DIFF
--- a/src/Fetcher/fetcher.go
+++ b/src/Fetcher/fetcher.go
@@ -44,8 +44,7 @@ func FetchFiles(url, branch, specFile string) error {
 		
 		os.Rename(path, ("cache/" + fileName[len(fileName)-1]))
 		
-		// Runs verifier on downloaded file to remove duplicates and ensure data integrity
-		
+		// Runs data integrity verifier on downloaded file
 		file := "./cache/"+fileName[len(fileName)-1]
 		err := Verifier.Verifier(file)
 		if err != nil {

--- a/src/Merger/merger.go
+++ b/src/Merger/merger.go
@@ -79,9 +79,14 @@ func MergeCSV(filepaths []string) error {
 	os.Remove("Merged_file.csv") // Remove file in case it already exists
 	var buf bytes.Buffer
 
-	// Run verifier on files
-
+	// Run data verifier on files
 	err := Verifier.Verifier(filepaths...)
+	if err != nil {
+		panic(err)
+	}
+
+	// Run duplicate removal on files
+	err = Verifier.DuplicateRemoval(filepaths...)
 	if err != nil {
 		panic(err)
 	}

--- a/src/Verifier/verifier.go
+++ b/src/Verifier/verifier.go
@@ -18,7 +18,7 @@ import (
 // 					`
 
 // Map of alternative names for the same blip
-var alt_names = make(map[string]string)//{"golang":"Go","go-lang:Go","cpp":"C++","csharp":"C#","cs":"C#","python3":"Python","py":"Python"}
+var alt_names = make(map[string]string) //{"golang":"Go","go-lang:Go","cpp":"C++","csharp":"C#","cs":"C#","python3":"Python","py":"Python"}
 
 // Checks that the given string matches the defined header of the specfile
 func checkHeader(header string) bool {
@@ -26,7 +26,7 @@ func checkHeader(header string) bool {
 	return header == correctHeader
 }
 
-// The pattern is created as a singleton so that we don't need 
+// The pattern is created as a singleton so that we don't need
 // to compile a new on every line that is checked
 var regexPattern *regexp.Regexp = nil
 
@@ -34,33 +34,64 @@ var regexPattern *regexp.Regexp = nil
 func createRegexPattern(ring1, ring2, ring3, ring4 string) {
 	var err error
 	regexPattern, err = regexp.Compile(fmt.Sprintf("^(([^,\n])([^,\n])*),([%s]%s|[%s]%s|[%s]%s|[%s]%s),([Dd]ata management|[Dd]atastore|[Ii]nfrastructure|[Ll]anguage),(false|true),-?[0123],(([^,\n])([^,\n])*)",
-								strings.ToUpper(ring1[:1]) + strings.ToLower(ring1[:1]), ring1[1:], strings.ToUpper(ring2[:1]) + strings.ToLower(ring2[:1]), ring2[1:], 
-								strings.ToUpper(ring3[:1]) + strings.ToLower(ring3[:1]), ring3[1:], strings.ToUpper(ring4[:1]) + strings.ToLower(ring4[:1]), ring4[1:]))
+		strings.ToUpper(ring1[:1])+strings.ToLower(ring1[:1]), ring1[1:], strings.ToUpper(ring2[:1])+strings.ToLower(ring2[:1]), ring2[1:],
+		strings.ToUpper(ring3[:1])+strings.ToLower(ring3[:1]), ring3[1:], strings.ToUpper(ring4[:1])+strings.ToLower(ring4[:1]), ring4[1:]))
 	if err != nil {
 		panic(err)
 	}
 }
 
-// Checks that the given string matches the correct 
+// Checks that the given string matches the correct
 // format for data in a specfile
 func checkDataLine(data string) bool {
 	if regexPattern == nil { // Check if we need to compile the pattern
 		createRegexPattern("hold", "assess", "trial", "adopt")
 	}
-	
+
 	match := regexPattern.MatchString(data)
 
 	return match
 }
 
-func Verifier (filepaths ... string) error {
-	// Map functions as a set (name -> ring)
-	var set = make(map[string][]string)
+func Verifier(filepaths ...string) error {
 	for _, filepath := range filepaths {
 		file, err := os.Open(filepath)
 		if err != nil {
 			panic(err)
 		}
+
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+
+		//TODO: Check if header matches (this will be another branch) for now it will just eat the first line
+		scanner.Scan()
+		if !checkHeader(scanner.Text()) {
+			return errors.New("The header of " + filepath + " is not correct.\n\tCorrect header: name,ring,quadrant,isNew,moved,description\n\tHeader of " + filepath + ": " + scanner.Text())
+		}
+
+		// https://stackoverflow.com/questions/44073754/how-to-slice-string-till-particular-character-in-go
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			if line == "" {
+				break
+			}
+
+			check := checkDataLine(line)
+
+			if !check {
+				return errors.New(filepath + " contains invalid data: " + scanner.Text())
+			}
+		}
+	}
+	return nil
+}
+
+func DuplicateRemoval(filepaths ...string) error {
+	// Map functions as a set (name -> ring)
+	var set = make(map[string][]string)
+	for _, filepath := range filepaths {
 
 		// Create temp file to overwrite primary file
 		tempfile, err := os.Create("tempfile.csv")
@@ -70,41 +101,31 @@ func Verifier (filepaths ... string) error {
 
 		defer os.RemoveAll(tempfile.Name())
 		defer tempfile.Close()
-		defer file.Close()
 
-		scanner := bufio.NewScanner(file)
-		
-		//TODO: Check if header matches (this will be another branch) for now it will just eat the first line
-		scanner.Scan()
-		if !checkHeader(scanner.Text()) {
-			return errors.New("The header of " + filepath + " is not correct.\n\tCorrect header: name,ring,quadrant,isNew,moved,description\n\tHeader of "+ filepath + ": " + scanner.Text())
+		file, err := os.Open(filepath)
+		if err != nil {
+			panic(err)
 		}
-		tempfile.WriteString(scanner.Text()+"\n")
-		
-		// https://stackoverflow.com/questions/44073754/how-to-slice-string-till-particular-character-in-go
+
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+
+		// Skip header
+		scanner.Scan()
+		tempfile.WriteString(scanner.Text() + "\n")
+
 		for scanner.Scan() {
 			line := scanner.Text()
-
-			if line == "" {
-				break
-			}
-			
-			check := checkDataLine(line)
-
-			if !check {
-				return errors.New(filepath + " contains invalid data: " + scanner.Text())
-			}
-
 			// Faster than splitting
-			// Panic handler 
+			// Panic handler
 			name := ""
 			index := strings.IndexByte(line, ',')
 			if index != -1 {
 				name = line[:index]
-			} 
+			}
 
 			duplicateRemoval(name, line, tempfile, set)
-			
+
 		}
 		file.Close()
 		tempfile.Close()
@@ -113,7 +134,6 @@ func Verifier (filepaths ... string) error {
 			panic(err)
 		}
 	}
-	
 	return nil
 }
 
@@ -130,14 +150,14 @@ func duplicateRemoval(name, line string, tempfile *os.File, set map[string][]str
 
 	if set[name] != nil {
 		// Skips the name + first comma and does the same forward search for next comma
-		ring := line[len(real_name)+1:strings.IndexByte(line[len(real_name)+1:], ',')+len(real_name)+1]
+		ring := line[len(real_name)+1 : strings.IndexByte(line[len(real_name)+1:], ',')+len(real_name)+1]
 		if !(slices.Contains(set[name], ring)) {
-			set[name] = append(set[name],ring)
-			tempfile.WriteString(line+"\n")	
+			set[name] = append(set[name], ring)
+			tempfile.WriteString(line + "\n")
 		}
 	} else {
-		set[name] = append(set[name],line[len(name)+1:strings.IndexByte(line[len(name)+1:], ',')+len(name)+1])
-		tempfile.WriteString(line+"\n")
+		set[name] = append(set[name], line[len(name)+1:strings.IndexByte(line[len(name)+1:], ',')+len(name)+1])
+		tempfile.WriteString(line + "\n")
 	}
 	// Overwrite filepath with tempfile (has the removed changes)
 	return nil

--- a/src/Verifier/verifier_test.go
+++ b/src/Verifier/verifier_test.go
@@ -55,6 +55,17 @@ func TestVerifierFunctionDuplicateDeletion(t *testing.T) {
 	}
 }
 
+func TestVerifier(t *testing.T) {
+	createCsvFiles(csvfile1)
+	defer cleanUp()
+
+	err := Verifier("./testFile1.csv")
+
+	if err != nil {
+		t.Fatalf("Verifier returned an error %v", err)
+	}
+}
+
 var csvfile2 string = `name,ring,quadrant,isNew,moved,description
 Go;Adopt?Language:true:0_Its a programming Language
 Visual Studio Code:Trial^Tool:false;2:An IDE

--- a/src/Verifier/verifier_test.go
+++ b/src/Verifier/verifier_test.go
@@ -34,7 +34,7 @@ func TestVerifierFunctionDuplicateDeletion(t *testing.T) {
 	createCsvFiles(csvfile1)
 	defer cleanUp()
 
-	Verifier("./testFile1.csv", "./testFile2.csv")
+	DuplicateRemoval("./testFile1.csv", "./testFile2.csv")
 
 	csv1, err := os.ReadFile("./testFile1.csv")
 	if err != nil {


### PR DESCRIPTION
... remove duplicate removal from fetcher

This PR splits the verifier calls to be two seperate calls making it possible to refactor the fetcher to run async

Resolves [#78](https://github.com/orgs/NovoNordisk-OpenSource/projects/2/views/1?pane=issue&itemId=59319977)