### PR TITLE
Refactor: move dublication removal

### DIFF
--- a/docs/dev_docs/merger.md
+++ b/docs/dev_docs/merger.md
@@ -36,5 +36,9 @@ The merger currently has three functions:
   * **What it does**: If the cache folder exists, it reads all files from said folder, and appends them to cachePaths. It then checks whether or not cachePaths contain anything, and if so, merges the file with `MergeCSV(cachePaths)`.
 
 * `DuplicateRemoval(filepaths ...string) error`
-  * **What it is:**: A public function that takes multiple filepaths to specfiles of type string
-  * **What it does**: Goes through the files given, removes duplicates, and overwrites the original file with a new file without the duplicates.
+  * **What it is:**: A public function that takes multiple filepaths to specfiles of type string.
+  * **What it does**: Goes through the files given line by line and calls `duplicateRemoval()` with each line.
+
+* `duplicateRemoval(name, line string, tempfile *os.File, set map[string][]string) error`
+  * **What it is**: A private function that takes a name of the blip in that line, the line, the tempfile for the current specfile, and the set for all the seen blips' names.
+  * **What it does**: Writes the line to the tempfile if the blip's name is not already in that quadrant. If the blip's name is already in the quadrant it is not added to the tempfile.

--- a/docs/dev_docs/merger.md
+++ b/docs/dev_docs/merger.md
@@ -8,6 +8,10 @@ This feature was developed to aggregate multiple specification files[[1]](#1-use
 
 This can be used to create an overview of e.g. an entire department's tech stack, which can be used for reviews, analysis, or other types of breakdowns.
 
+The merger ensures that no duplicates appear in the merged file. It checks the documents line by line and adds blips to a set of seen names and will remove any duplicate found in the future if it is in the same ring (this may be changed for LLM duplicate handling later). 
+
+The verifier uses a alt_names map to ensure that alternative names are counted as the same thing. E.g. C#, CSharp, CS will all be mapped the same value ensuring they are counted as the same thing. Currently this value is hardcoded.
+
 #### [1] [User Docs: Formatting specification files.](../user_docs/spec_file_format.md)
 
 ## Functions
@@ -30,3 +34,7 @@ The merger currently has three functions:
 * `MergeFromFolder(folderPath string) error`
   * **What it is**: A public function that takes one argument: A path to a folder, which in the default case, when adding the cache flag, is the cache folder itself.
   * **What it does**: If the cache folder exists, it reads all files from said folder, and appends them to cachePaths. It then checks whether or not cachePaths contain anything, and if so, merges the file with `MergeCSV(cachePaths)`.
+
+* `DuplicateRemoval(filepaths ...string) error`
+  * **What it is:**: A public function that takes multiple filepaths to specfiles of type string
+  * **What it does**: Goes through the files given, removes duplicates, and overwrites the original file with a new file without the duplicates.

--- a/docs/dev_docs/verifier.md
+++ b/docs/dev_docs/verifier.md
@@ -1,12 +1,7 @@
 # CSV Verifier
 The merger and fetcher use a CSV verifier to ensure that the CSV complies with what is expected from a specification file. This is done by checking that the header of the file matches the defined specification file header. 
 
-The verifier also ensures that exact duplicates don't occur as well as to ensure the integrity of the CSV file.
-
 The verifier is located in the Verifier package and can take any amount of filepaths. If the verifier finds a problem it will return an error. 
 ```go
 func Verifier (filepaths ... string) error 
 ```
-It checks the documents line by line and adds blips to a set of seen names and will remove any duplicate found in the future if it is in the same ring (this may be changed for LLM duplicate handling later). 
-
-The verifier uses a alt_names map to ensure that alternative names are counted as the same thing. E.g. C#, CSharp, CS will all be mapped the same value ensuring they are counted as the same thing. Currently this value is hardcoded.

--- a/src/Merger/merger.go
+++ b/src/Merger/merger.go
@@ -122,7 +122,7 @@ func MergeCSV(filepaths []string) error {
 }
 
 func DuplicateRemoval(filepaths ...string) error {
-	// Map functions as a set (name -> ring)
+	// Map functions as a set (name -> quadrant)
 	var set = make(map[string][]string)
 	for _, filepath := range filepaths {
 
@@ -183,15 +183,15 @@ func duplicateRemoval(name, line string, tempfile *os.File, set map[string][]str
 
 	if set[name] != nil {
 		// Skips the name + first comma and does the same forward search for next comma
-		ring := line[len(real_name)+1 : strings.IndexByte(line[len(real_name)+1:], ',')+len(real_name)+1]
-		if !(slices.Contains(set[name], ring)) {
-			set[name] = append(set[name], ring)
+		quadrant := line[len(real_name)+1 : strings.IndexByte(line[len(real_name)+1:], ',')+len(real_name)+1]
+		if !(slices.Contains(set[name], quadrant)) {
+			set[name] = append(set[name], quadrant)
 			tempfile.WriteString(line + "\n")
 		}
 	} else {
 		set[name] = append(set[name], line[len(name)+1:strings.IndexByte(line[len(name)+1:], ',')+len(name)+1])
 		tempfile.WriteString(line + "\n")
 	}
-	// Overwrite filepath with tempfile (has the removed changes)
+
 	return nil
 }

--- a/src/Merger/merger.go
+++ b/src/Merger/merger.go
@@ -7,8 +7,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"slices"
 	"github.com/NovoNordisk-OpenSource/decentralized-tech-radar/Verifier"
 )
+
+// Map of alternative names for the same blip
+var alt_names = make(map[string]string) //{"golang":"Go","go-lang:Go","cpp":"C++","csharp":"C#","cs":"C#","python3":"Python","py":"Python"}
 
 func getHeader(filepath string) ([]byte, error) {
 	file, err := os.Open(filepath)
@@ -86,7 +91,7 @@ func MergeCSV(filepaths []string) error {
 	}
 
 	// Run duplicate removal on files
-	err = Verifier.DuplicateRemoval(filepaths...)
+	err = DuplicateRemoval(filepaths...)
 	if err != nil {
 		panic(err)
 	}
@@ -113,5 +118,80 @@ func MergeCSV(filepaths []string) error {
 		return err
 	}
 
+	return nil
+}
+
+func DuplicateRemoval(filepaths ...string) error {
+	// Map functions as a set (name -> ring)
+	var set = make(map[string][]string)
+	for _, filepath := range filepaths {
+
+		// Create temp file to overwrite primary file
+		tempfile, err := os.Create("tempfile.csv")
+		if err != nil {
+			panic(err)
+		}
+
+		defer os.RemoveAll(tempfile.Name())
+		defer tempfile.Close()
+
+		file, err := os.Open(filepath)
+		if err != nil {
+			panic(err)
+		}
+
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+
+		// Skip header
+		scanner.Scan()
+		tempfile.WriteString(scanner.Text() + "\n")
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			// Faster than splitting
+			// Panic handler
+			name := ""
+			index := strings.IndexByte(line, ',')
+			if index != -1 {
+				name = line[:index]
+			}
+
+			duplicateRemoval(name, line, tempfile, set)
+
+		}
+		file.Close()
+		tempfile.Close()
+		err = os.Rename("tempfile.csv", filepath)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return nil
+}
+
+func duplicateRemoval(name, line string, tempfile *os.File, set map[string][]string) error {
+	//TODO: Unmarshal the json file (or some other file based solution) to get the alternative names
+	// Or just use a baked in str read line by line or combination
+	//os.Stat("./Dictionary/alt_names.txt")
+
+	real_name := name
+	if alt_names[name] != "" {
+		//TODO: Figure out how to handle numbers in names
+		name = alt_names[strings.ToLower(name)]
+	}
+
+	if set[name] != nil {
+		// Skips the name + first comma and does the same forward search for next comma
+		ring := line[len(real_name)+1 : strings.IndexByte(line[len(real_name)+1:], ',')+len(real_name)+1]
+		if !(slices.Contains(set[name], ring)) {
+			set[name] = append(set[name], ring)
+			tempfile.WriteString(line + "\n")
+		}
+	} else {
+		set[name] = append(set[name], line[len(name)+1:strings.IndexByte(line[len(name)+1:], ',')+len(name)+1])
+		tempfile.WriteString(line + "\n")
+	}
+	// Overwrite filepath with tempfile (has the removed changes)
 	return nil
 }

--- a/src/Merger/merger_test.go
+++ b/src/Merger/merger_test.go
@@ -56,6 +56,31 @@ func TestGetHeader(t *testing.T) {
 	}
 }
 
+func TestDuplicateDeletion(t *testing.T) {
+	createCsvFiles()
+	defer cleanUp()
+
+	DuplicateRemoval("./testFile1.csv", "./testFile2.csv")
+
+	csv1, err := os.ReadFile("./testFile1.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(csv1), csvfile1) {
+		t.Fatalf("csvFile1 does not match expected output.\nExpected: %s \n Actual: %s", csvfile1, csv1)
+	}
+
+	csv2, err := os.ReadFile("./testFile2.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(csv2) != "name,ring,quadrant,isNew,moved,description\nPython,Hold,Language,false,0,Its a programming Language\nVisual Studio,Trial,Infrastructure,false,1,An IDE\n" {
+		t.Fatalf("csvFile2 does not match expected output.\nExpected: name,ring,quadrant,isNew,moved,description \nActual: %s",csv2)
+	}
+}
+
 func TestReadCsvContent(t *testing.T) {
 	createCsvFiles()
 	defer cleanUp()

--- a/src/Verifier/verifier_test.go
+++ b/src/Verifier/verifier_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"log"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -30,30 +29,30 @@ func cleanUp() {
 	os.Remove("tempfile.csv")
 }
 
-func TestVerifierFunctionDuplicateDeletion(t *testing.T) {
-	createCsvFiles(csvfile1)
-	defer cleanUp()
+// func TestVerifierFunctionDuplicateDeletion(t *testing.T) {
+// 	createCsvFiles(csvfile1)
+// 	defer cleanUp()
 
-	DuplicateRemoval("./testFile1.csv", "./testFile2.csv")
+// 	DuplicateRemoval("./testFile1.csv", "./testFile2.csv")
 
-	csv1, err := os.ReadFile("./testFile1.csv")
-	if err != nil {
-		t.Fatal(err)
-	}
+// 	csv1, err := os.ReadFile("./testFile1.csv")
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	if !strings.Contains(string(csv1), csvfile1) {
-		t.Fatalf("csvFile1 does not match expected output.\nExpected: %s \n Actual: %s", csvfile1, csv1)
-	}
+// 	if !strings.Contains(string(csv1), csvfile1) {
+// 		t.Fatalf("csvFile1 does not match expected output.\nExpected: %s \n Actual: %s", csvfile1, csv1)
+// 	}
 
-	csv2, err := os.ReadFile("./testFile2.csv")
-	if err != nil {
-		t.Fatal(err)
-	}
+// 	csv2, err := os.ReadFile("./testFile2.csv")
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	if string(csv2) != "name,ring,quadrant,isNew,moved,description\n" {
-		t.Fatalf("csvFile2 does not match expected output.\nExpected: name,ring,quadrant,isNew,moved,description \nActual: %s",csv2)
-	}
-}
+// 	if string(csv2) != "name,ring,quadrant,isNew,moved,description\n" {
+// 		t.Fatalf("csvFile2 does not match expected output.\nExpected: name,ring,quadrant,isNew,moved,description \nActual: %s",csv2)
+// 	}
+// }
 
 func TestVerifier(t *testing.T) {
 	createCsvFiles(csvfile1)


### PR DESCRIPTION
Since the duplication removal only applies to the merger it makes more sence that the function comes from there and not the verifier. This also makes it easier when we want to make it so that duplication removal doesn't overwrite the existing specfiles.

Resolves: [#101](https://github.com/orgs/NovoNordisk-OpenSource/projects/2/views/3?pane=issue&itemId=60564219)