### PR TITLE
chore: create .gitattributes and add linguist vendor ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.css linguist-vendored


### PR DESCRIPTION
This PR includes a very small QoL update. This adds a .gitattributes file that has a linguist vendor line inside. This tells Github to ignore those files when creating the language distribution for the repo. I have excluded the CSS since it looks kinda wack that 88% of the project is CSS. We can also add the JS to this if it too becomes too dominant but we can discuss this as a group

[Article Explaining how it works](https://proandroiddev.com/removing-noise-from-your-github-language-stats-e96113f8183d)

Resolves [#106](https://github.com/orgs/NovoNordisk-OpenSource/projects/2/views/1?pane=issue&itemId=60903680)