### PR TITLE
fix: change quadrant names and make them editable

### DIFF
--- a/examples/csv_templates/template.csv
+++ b/examples/csv_templates/template.csv
@@ -1,4 +1,4 @@
 name,ring,quadrant,isNew,moved,description
-Python,hold,language,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.
-web,hold,language,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.
-react,hold,language,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.
+Python,hold,Languages & Frameworks,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.
+web,hold,Languages & Frameworks,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.
+react,hold,Languages & Frameworks,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.

--- a/src/HTML/js/renderingTechRadar.js
+++ b/src/HTML/js/renderingTechRadar.js
@@ -55,7 +55,7 @@ define([
   const quadrantGap = 32;
 
   const quadrantNames =
-    '["Language", "Infrastructure", "Datastore", "Data management"]';
+    '["Techniques", "Platforms", "Tools", "Languages & Frameworks"]';
   const ringNames = '["Adopt", "Trial", "Assess", "Hold"]';
 
   const getQuadrants = () => {

--- a/src/Merger/merger_test.go
+++ b/src/Merger/merger_test.go
@@ -13,29 +13,29 @@ import (
 )
 
 var csvfile1 string = `name,ring,quadrant,isNew,moved,description
-Go,Adopt,Language,true,0,Its a programming Language
-Visual Studio Code,Trial,Infrastructure,false,2,An IDE
-Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing`
+Go,Adopt,Languages & frameworks,true,0,Its a programming Language
+Visual Studio Code,Trial,Platforms,false,2,An IDE
+Dagger IO,Assess,Tools,true,1,Its a workflow thing`
 
 var csvfile2 string = `name,ring,quadrant,isNew,moved,description
-Python,Hold,Language,false,0,Its a programming Language
-Visual Studio,Trial,Infrastructure,false,1,An IDE
-Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing`
+Python,Hold,Languages & frameworks,false,0,Its a programming Language
+Visual Studio,Trial,Platforms,false,1,An IDE
+Dagger IO,Assess,Tools,true,1,Its a workflow thing`
 
 var correctMerge string = `name,ring,quadrant,isNew,moved,description
-Go,Adopt,Language,true,0,Its a programming Language
-Visual Studio Code,Trial,Infrastructure,false,2,An IDE
-Visual Studio,Trial,Infrastructure,false,1,An IDE
-Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing
-Python,Hold,Language,false,0,Its a programming Language`
+Go,Adopt,Languages & frameworks,true,0,Its a programming Language
+Visual Studio Code,Trial,Platforms,false,2,An IDE
+Visual Studio,Trial,Platforms,false,1,An IDE
+Dagger IO,Assess,Tools,true,1,Its a workflow thing
+Python,Hold,Languages & frameworks,false,0,Its a programming Language`
 
 // The strings below are used exclusively to test
 // ReadCsvFile's majority-vote-based tool-duplication deletion.
 
 var csvfile3 string = `name,ring,quadrant,isNew,moved,description
-Go,Trial,Language,true,0,Its a programming Language
-Visual Studio Code,Trial,Infrastructure,false,2,An IDE
-Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing`
+Go,Trial,Languages & frameworks,true,0,Its a programming Language
+Visual Studio Code,Trial,Platforms,false,2,An IDE
+Dagger IO,Assess,Tools,true,1,Its a workflow thing`
 
 // TODO: Discuss handling ties.
 //var csvfile4 string = `name,ring,quadrant,isNew,moved,description
@@ -44,10 +44,10 @@ Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing`
 //Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing`
 
 var correctMergeMajority string = `name,ring,quadrant,isNew,moved,description
-Go,Adopt,Language,true,0,Its a programming Language
-Visual Studio Code,Trial,Infrastructure,false,2,An IDE
-Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing
-Python,Hold,Language,false,0,Its a programming Language`
+Go,Adopt,Languages & frameworks,true,0,Its a programming Language
+Visual Studio Code,Trial,Platforms,false,2,An IDE
+Dagger IO,Assess,Tools,true,1,Its a workflow thing
+Python,Hold,Languages & frameworks,false,0,Its a programming Language`
 
 var oldTestFiles []string = []string{"testFile1.csv", "testFile2.csv"}
 var testFiles []string = []string{"testFile1.csv", "testFile2.csv", "testFile3.csv"}
@@ -119,9 +119,9 @@ func TestDuplicateRemoval(t *testing.T) {
 	}()
 
 	// Arrange input
-	var csvfile0 string = "Go,Adopt,Language,true,0,Its a programming Language\n" +
-		"Go,Adopt,Language,true,0,Its a programming Language\n" +
-		"Python,Hold,Language,false,0,Its a programming Language\n"
+	var csvfile0 string = "Go,Adopt,Languages & frameworks,true,0,Its a programming Language\n" +
+		"Go,Adopt,Languages & frameworks,true,0,Its a programming Language\n" +
+		"Python,Hold,Languages & frameworks,false,0,Its a programming Language\n"
 
 	err := os.WriteFile(filename, []byte(csvfile0), 0644)
 	if err != nil {
@@ -142,8 +142,8 @@ func TestDuplicateRemoval(t *testing.T) {
 	}()
 
 	// Arrange expected output
-	var expectedString string = "Go,Adopt,Language,true,0,Its a programming Language\n" +
-		"Python,Hold,Language,false,0,Its a programming Language\n"
+	var expectedString string = "Go,Adopt,Languages & frameworks,true,0,Its a programming Language\n" +
+		"Python,Hold,Languages & frameworks,false,0,Its a programming Language\n"
 
 	// Arrange other variables to be used
 	var set = make(map[string][]string)
@@ -192,11 +192,11 @@ func TestReadCsvData(t *testing.T) {
 		t.Errorf("csvFile2 does not match expected output.\nExpected: %s \n Actual: %s", csvfile2, csv2)
 	}
 
-	correctString := `Go,Adopt,Language,true,0,Its a programming Language
-Visual Studio Code,Trial,Infrastructure,false,2,An IDE
-Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing
-Python,Hold,Language,false,0,Its a programming Language
-Visual Studio,Trial,Infrastructure,false,1,An IDE`
+	correctString := `Go,Adopt,Languages & frameworks,true,0,Its a programming Language
+Visual Studio Code,Trial,Platforms,false,2,An IDE
+Dagger IO,Assess,Tools,true,1,Its a workflow thing
+Python,Hold,Languages & frameworks,false,0,Its a programming Language
+Visual Studio,Trial,Platforms,false,1,An IDE`
 
 	bufferString := buf.String()
 	if strings.Compare(bufferString, correctString) == 0 {

--- a/src/Verifier/verifier.go
+++ b/src/Verifier/verifier.go
@@ -27,7 +27,7 @@ func checkHeader(header string) bool {
 var regexPattern *regexp.Regexp = nil
 
 // Creates the regex pattern string with the names on the rings
-func createRegexPattern(ring1, ring2, ring3, ring4 string) {
+func createRegexPattern(ring1, ring2, ring3, ring4, qudrant1, quadrant2, quadrant3, quadrant4 string) {
 	var err error
 	// This is the regex pattern that matches the correct format for a data line in the csv specfile
 	// Example of a correct line:

--- a/src/Verifier/verifier.go
+++ b/src/Verifier/verifier.go
@@ -34,9 +34,6 @@ func createRegexPattern(ring1, ring2, ring3, ring4, quadrant1, quadrant2, quadra
 	// 		Python,hold,language,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.
 	// Example of a incorrect line:
 	// 		Python,wait,infrastructure,False,5,Lorem ipsum dolor sit amet consectetur adipiscing elit.
-	fmt.Printf("[%s]%s|[%s]%s|[%s]%s|[%s]%s",
-		strings.ToUpper(quadrant1[:1])+strings.ToLower(quadrant1[:1]), quadrant1[1:], strings.ToUpper(quadrant2[:1])+strings.ToLower(quadrant2[1:]), quadrant2[1:],
-		strings.ToUpper(quadrant3[:1])+strings.ToLower(quadrant3[:1]), quadrant3[1:], strings.ToUpper(quadrant4[:1])+strings.ToLower(quadrant4[1:]), quadrant4[1:])
 
 	regexPattern, err = regexp.Compile(fmt.Sprintf("^(([^,\n])([^,\n])*),([%s]%s|[%s]%s|[%s]%s|[%s]%s),([%s]%s|[%s]%s|[%s]%s|[%s]%s),(false|true),-?[0123],(([^,\n])([^,\n])*)",
 		strings.ToUpper(ring1[:1])+strings.ToLower(ring1[:1]), ring1[1:], strings.ToUpper(ring2[:1])+strings.ToLower(ring2[:1]), ring2[1:],
@@ -47,8 +44,6 @@ func createRegexPattern(ring1, ring2, ring3, ring4, quadrant1, quadrant2, quadra
 		panic(err)
 	}
 }
-
-// ([Tt]echniques|[Pp]latforms|[Tt]ools|[Ll]anguages & Frameworks)
 
 // Checks that the given string matches the correct
 // format for data in a specfile

--- a/src/Verifier/verifier.go
+++ b/src/Verifier/verifier.go
@@ -34,21 +34,27 @@ func createRegexPattern(ring1, ring2, ring3, ring4, quadrant1, quadrant2, quadra
 	// 		Python,hold,language,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.
 	// Example of a incorrect line:
 	// 		Python,wait,infrastructure,False,5,Lorem ipsum dolor sit amet consectetur adipiscing elit.
-	regexPattern, err = regexp.Compile(fmt.Sprintf("^(([^,\n])([^,\n])*),([%s]%s|[%s]%s|[%s]%s|[%s]%s|[%s]%s|[%s]%s|[%s]%s|[%s]%s),([Tt]Techniques|[Pp]latforms|[Tt]ools|[Ff]rameworks),(false|true),-?[0123],(([^,\n])([^,\n])*)",
+	fmt.Printf("[%s]%s|[%s]%s|[%s]%s|[%s]%s",
+		strings.ToUpper(quadrant1[:1])+strings.ToLower(quadrant1[:1]), quadrant1[1:], strings.ToUpper(quadrant2[:1])+strings.ToLower(quadrant2[1:]), quadrant2[1:],
+		strings.ToUpper(quadrant3[:1])+strings.ToLower(quadrant3[:1]), quadrant3[1:], strings.ToUpper(quadrant4[:1])+strings.ToLower(quadrant4[1:]), quadrant4[1:])
+
+	regexPattern, err = regexp.Compile(fmt.Sprintf("^(([^,\n])([^,\n])*),([%s]%s|[%s]%s|[%s]%s|[%s]%s),([%s]%s|[%s]%s|[%s]%s|[%s]%s),(false|true),-?[0123],(([^,\n])([^,\n])*)",
 		strings.ToUpper(ring1[:1])+strings.ToLower(ring1[:1]), ring1[1:], strings.ToUpper(ring2[:1])+strings.ToLower(ring2[:1]), ring2[1:],
 		strings.ToUpper(ring3[:1])+strings.ToLower(ring3[:1]), ring3[1:], strings.ToUpper(ring4[:1])+strings.ToLower(ring4[:1]), ring4[1:],
-		strings.ToUpper(quadrant1[:1])+strings.ToLower(quadrant1[:1]), quadrant1[1:], strings.ToUpper(quadrant2[:1])+strings.ToLower(quadrant2[:1]), quadrant2[:1],
-		strings.ToUpper(quadrant3[:1])+strings.ToLower(quadrant3[:1]), quadrant3[1:], strings.ToUpper(quadrant4[:1])+strings.ToLower(quadrant4[:1]), quadrant4[:1]))
+		strings.ToUpper(quadrant1[:1])+strings.ToLower(quadrant1[:1]), quadrant1[1:], strings.ToUpper(quadrant2[:1])+strings.ToLower(quadrant2[:1]), quadrant2[1:],
+		strings.ToUpper(quadrant3[:1])+strings.ToLower(quadrant3[:1]), quadrant3[1:], strings.ToUpper(quadrant4[:1])+strings.ToLower(quadrant4[:1]), quadrant4[1:]))
 	if err != nil {
 		panic(err)
 	}
 }
 
+// ([Tt]echniques|[Pp]latforms|[Tt]ools|[Ll]anguages & Frameworks)
+
 // Checks that the given string matches the correct
 // format for data in a specfile
 func checkDataLine(data string) bool {
 	if regexPattern == nil { // Check if we need to compile the pattern
-		createRegexPattern("hold", "assess", "trial", "adopt", "Techniques", "Platforms", "Tools", "Frameworks")
+		createRegexPattern("hold", "assess", "trial", "adopt", "techniques", "platforms", "tools", "languages & frameworks")
 	}
 
 	match := regexPattern.MatchString(data)

--- a/src/Verifier/verifier.go
+++ b/src/Verifier/verifier.go
@@ -27,16 +27,18 @@ func checkHeader(header string) bool {
 var regexPattern *regexp.Regexp = nil
 
 // Creates the regex pattern string with the names on the rings
-func createRegexPattern(ring1, ring2, ring3, ring4, qudrant1, quadrant2, quadrant3, quadrant4 string) {
+func createRegexPattern(ring1, ring2, ring3, ring4, quadrant1, quadrant2, quadrant3, quadrant4 string) {
 	var err error
 	// This is the regex pattern that matches the correct format for a data line in the csv specfile
 	// Example of a correct line:
 	// 		Python,hold,language,false,0,Lorem ipsum dolor sit amet consectetur adipiscing elit.
 	// Example of a incorrect line:
 	// 		Python,wait,infrastructure,False,5,Lorem ipsum dolor sit amet consectetur adipiscing elit.
-	regexPattern, err = regexp.Compile(fmt.Sprintf("^(([^,\n])([^,\n])*),([%s]%s|[%s]%s|[%s]%s|[%s]%s),([Dd]ata management|[Dd]atastore|[Ii]nfrastructure|[Ll]anguage),(false|true),-?[0123],(([^,\n])([^,\n])*)",
+	regexPattern, err = regexp.Compile(fmt.Sprintf("^(([^,\n])([^,\n])*),([%s]%s|[%s]%s|[%s]%s|[%s]%s|[%s]%s|[%s]%s|[%s]%s|[%s]%s),([Tt]Techniques|[Pp]latforms|[Tt]ools|[Ff]rameworks),(false|true),-?[0123],(([^,\n])([^,\n])*)",
 		strings.ToUpper(ring1[:1])+strings.ToLower(ring1[:1]), ring1[1:], strings.ToUpper(ring2[:1])+strings.ToLower(ring2[:1]), ring2[1:],
-		strings.ToUpper(ring3[:1])+strings.ToLower(ring3[:1]), ring3[1:], strings.ToUpper(ring4[:1])+strings.ToLower(ring4[:1]), ring4[1:]))
+		strings.ToUpper(ring3[:1])+strings.ToLower(ring3[:1]), ring3[1:], strings.ToUpper(ring4[:1])+strings.ToLower(ring4[:1]), ring4[1:],
+		strings.ToUpper(quadrant1[:1])+strings.ToLower(quadrant1[:1]), quadrant1[1:], strings.ToUpper(quadrant2[:1])+strings.ToLower(quadrant2[:1]), quadrant2[:1],
+		strings.ToUpper(quadrant3[:1])+strings.ToLower(quadrant3[:1]), quadrant3[1:], strings.ToUpper(quadrant4[:1])+strings.ToLower(quadrant4[:1]), quadrant4[:1]))
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +48,7 @@ func createRegexPattern(ring1, ring2, ring3, ring4, qudrant1, quadrant2, quadran
 // format for data in a specfile
 func checkDataLine(data string) bool {
 	if regexPattern == nil { // Check if we need to compile the pattern
-		createRegexPattern("hold", "assess", "trial", "adopt")
+		createRegexPattern("hold", "assess", "trial", "adopt", "Techniques", "Platforms", "Tools", "Frameworks")
 	}
 
 	match := regexPattern.MatchString(data)
@@ -88,4 +90,3 @@ func Verifier(filepaths ...string) error {
 	}
 	return nil
 }
-

--- a/src/Verifier/verifier_test.go
+++ b/src/Verifier/verifier_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 var csvfile1 string = `name,ring,quadrant,isNew,moved,description
-Go,Adopt,Language,true,0,Its a programming Language
-Visual Studio Code,Trial,Infrastructure,false,2,An IDE
-Dagger IO,Assess,Infrastructure,true,1,Its a workflow thing`
+Go,Adopt,Languages & frameworks,true,0,Its a programming Language
+Visual Studio Code,Trial,Platforms,false,2,An IDE
+Dagger IO,Assess,Tools,true,1,Its a workflow thing`
 
 func createCsvFiles(csvfile string) {
 	err := os.WriteFile("testFile1.csv", []byte(csvfile), 0644)
@@ -41,7 +41,7 @@ func TestVerifier(t *testing.T) {
 }
 
 var csvfile2 string = `name,ring,quadrant,isNew,moved,description
-Go;Adopt?Language:true:0_Its a programming Language
+Go;Adopt?Languages & Frameworks:true:0_Its a programming Language
 Visual Studio Code:Trial^Tool:false;2:An IDE
 Dagger IO;Assess*Tool+true?1_Its a workflow thing`
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -90,14 +90,14 @@ func TestAddCmd(t *testing.T) {
 	startProgram(t)
 
 	// Run the Add command
-	cmd1 := exec.Command("./tech_radar.exe", "add", "ForTesting1.csv", "fakeLang", "assess", "language", "false", "0", "no lorem")
+	cmd1 := exec.Command("./tech_radar.exe", "add", "ForTesting1.csv", "fakeLang", "assess", "Languages & Frameworks", "false", "0", "no lorem")
 	_, err := cmd1.Output()
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 
 	// Create slice with expected elements in the line appended
-	correctAdd := []string{"fakeLang", "assess", "language", "false", "0", "no lorem"}
+	correctAdd := []string{"fakeLang", "assess", "Languages & Frameworks", "false", "0", "no lorem"}
 
 	// Read the ForTesting1.csv for asserts later
 	readTestFile, err := os.ReadFile("ForTesting1.csv")
@@ -188,7 +188,7 @@ func TestRemCmd(t *testing.T) {
 	}
 
 	// Run the Remove command
-	cmd1 := exec.Command("./tech_radar.exe", "remove", "ForTesting1.csv", "TestBlip2", "Infrastructure")
+	cmd1 := exec.Command("./tech_radar.exe", "remove", "ForTesting1.csv", "TestBlip2", "Platforms")
 	_, err = cmd1.Output()
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -206,7 +206,7 @@ func TestRemCmd(t *testing.T) {
 	}
 
 	// Check if csv DOES NOT contain the removed line.
-	if strings.Contains(string(readTestFile), "TestBlip2,Adopt,Infrastructure,false,0,Also a description") {
-		t.Error("1: ForTesting1.csv contains TestBlip2 in Infrastructure")
+	if strings.Contains(string(readTestFile), "TestBlip2,Adopt,Platforms,false,0,Also a description") {
+		t.Error("1: ForTesting1.csv contains TestBlip2 in Platforms")
 	}
 }


### PR DESCRIPTION
This fix includes quadrant name changes to reflect Thoughtworks' own quadrant, and making them editable.

Notices:
 - End2end test is not working since the quardant names are not the same on Novo's repo 