### PR TITLE
Fix: link to thoughtworks in index footer re-added

### DIFF
--- a/src/HTML/makeHtml.go
+++ b/src/HTML/makeHtml.go
@@ -44,7 +44,7 @@ func GenerateHtml(csvData string) {
 			</div>
 			<div class="all-quadrants-mobile show-all-quadrants-mobile"></div>
 			<div class="graph-footer">
-				<p class="agree-terms">Visit the Novo Nordisk <a href="https://github.com/NovoNordisk-OpenSource/decentralized-tech-radar">Tech Radar open source on Github</a>. This tech radar was heavily inspired by Thoughtworks.</p>
+				<p class="agree-terms">Visit the Novo Nordisk <a href="https://github.com/NovoNordisk-OpenSource/decentralized-tech-radar">Tech Radar open source on Github</a>. This tech radar was heavily inspired by <a href="https://github.com/thoughtworks/build-your-own-radar/">Thoughtworks</a>.</p>
 			</div>
 		</main>
 	</body>


### PR DESCRIPTION
For some reason this was lost in an earlier merge, now the link to thoughtworks is re-added to the footer.